### PR TITLE
Synchronously fetched the script for tracing web audio calls.

### DIFF
--- a/extension/injection-content-script.js
+++ b/extension/injection-content-script.js
@@ -8,57 +8,79 @@
  */
 
 
-// Execute the instrumentation script by attaching then removing a script tag.
-var scriptTag = document.createElement('script');
-scriptTag.src = chrome.extension.getURL('tracing.js');
-(document.head || document.documentElement).appendChild(scriptTag);
-scriptTag.remove();
+/**
+ * The XHR request that synchronously fetches the JS for tracing web audio
+ * calls. The script is fetched as a string we use to create a script tag. We
+ * synchronously fetch to prevent other JS from running before the JS for
+ * tracing runs. Setting the 'src' attribute of a script tag does not work since
+ * that does not actually block JS execution.
+ * @type {!XMLHttpRequest}
+ */
+var requestForTracingScript = new XMLHttpRequest();
 
 
-// Connect with the background page so that it can relay web audio updates to
-// the panel JS.
-var backgroundPageConnection = chrome.runtime.connect({
-  'name': 'init_frame'
-});
+/**
+ * Injects the code for tracing web audio calls into the web page via a script
+ * tag. Sets up a connection with the background script for routing messages.
+ */
+requestForTracingScript.onload = function() {
+  // Execute the instrumentation script by attaching then removing a script tag.
+  var scriptTag = document.createElement('script');
+  scriptTag.textContent = requestForTracingScript.responseText;
+  (document.head || document.documentElement).appendChild(scriptTag);
+  scriptTag.remove();
 
 
-// TODO: Respond to messages from the background page.
-backgroundPageConnection.onMessage.addListener(function(message) {
-  var messageType = message['type'];
-});
+  // Connect with the background page so that it can relay web audio updates to
+  // the panel JS.
+  var backgroundPageConnection = chrome.runtime.connect({
+    'name': 'init_frame'
+  });
 
 
-// Listen to messages from the page. Relay them to the background script.
-window.addEventListener('message', function(event) {
-  if (event.source != window) {
-    // We are not interested in messages from other windows.
-    return;
-  }
+  // TODO: Respond to messages from the background page.
+  backgroundPageConnection.onMessage.addListener(function(message) {
+    var messageType = message['type'];
+  });
 
-  var message = event.data;
-  if (!message || message['tag'] != 'webAudioExtension') {
-    // This message is not relevant to this extension.
-    return;
-  }
 
-  switch (message['type']) {
-    case 'new_context':
-      // A new AudioContext has been created.
-    case 'add_node':
-      // A node has been added to the audio graph.
-    case 'add_edge':
-      // An edge has been added to the audio graph.
-    case 'remove_edge':
-      // An edge has been removed from the audio graph.
+  // Listen to messages from the page. Relay them to the background script.
+  window.addEventListener('message', function(event) {
+    if (event.source != window) {
+      // We are not interested in messages from other windows.
+      return;
+    }
 
-      // We do not need the tag that identifies this message as from this
-      // extension if we are communicating with the background page. Prefer a
-      // smaller message (to serialize).
-      delete message['tag'];
-      backgroundPageConnection.postMessage(message);
-      break;
-  }
-});
+    var message = event.data;
+    if (!message || message['tag'] != 'webAudioExtension') {
+      // This message is not relevant to this extension.
+      return;
+    }
 
-// Indicate that this content script is ready to receive messages.
-backgroundPageConnection.postMessage({'type': 'listeners_ready'});
+    switch (message['type']) {
+      case 'new_context':
+        // A new AudioContext has been created.
+      case 'add_node':
+        // A node has been added to the audio graph.
+      case 'add_edge':
+        // An edge has been added to the audio graph.
+      case 'remove_edge':
+        // An edge has been removed from the audio graph.
+
+        // We do not need the tag that identifies this message as from this
+        // extension if we are communicating with the background page. Prefer a
+        // smaller message (to serialize).
+        delete message['tag'];
+        backgroundPageConnection.postMessage(message);
+        break;
+    }
+  });
+
+  // Indicate that this content script is ready to receive messages.
+  backgroundPageConnection.postMessage({'type': 'listeners_ready'});
+};
+
+// Synchronously request the script for tracing web audio calls.
+requestForTracingScript.open(
+    'GET', chrome.extension.getURL('tracing.js'), false);
+requestForTracingScript.send();


### PR DESCRIPTION
Synchronously fetched the script for tracing web audio calls before injecting it into a frame (via setting the textContent attribute of a script tag). Fetching that script via setting the src attribute of a script tag might seem simpler but actually does not work since doing that is non-blocking, so other JS might run before the tracing script executes (a race condition). Fixes #13.
