### PR TITLE
Make loading screen have a very light background to mitigate flicker.

### DIFF
--- a/js/entry-points/panel.css
+++ b/js/entry-points/panel.css
@@ -139,7 +139,7 @@ body {
 }
 
 #updates-missing-screen {
-  background: #ccc;
+  background: #fff;
   display: none;
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
This addresses issue #42. Screenshot of new loading screen:
<img width="992" alt="screen shot 2017-03-14 at 12 45 29 am" src="https://cloud.githubusercontent.com/assets/4221553/23890709/2feaec94-0850-11e7-9a24-7d529ca70ced.png">
Note the much lighter, rather transparent background. And the slightly darker spinner grey.
