### PR TITLE
Streamline (and fix) logic for positioning ports.

### DIFF
--- a/js/entry-points/panel.js
+++ b/js/entry-points/panel.js
@@ -463,7 +463,7 @@ audion.entryPoints.handleLinkCreated_ = function(link) {
  * @private
  */
 audion.entryPoints.handleNodeCreated_ = function(message) {
-    // Strip the node suffix. It is redundant.
+  // Strip the node suffix. It is redundant.
   var suffix = 'Node';
   var nodeType = message.nodeType
   if (nodeType.slice(-4) == suffix) {
@@ -680,7 +680,7 @@ audion.entryPoints.handleNodeCreated_ = function(message) {
         }
       },
       'items': ports
-    },
+    }
   }).addTo(audion.entryPoints.graph_);
 
   audion.entryPoints.requestRedraw_();


### PR DESCRIPTION
Used math to position input and AudioParam ports on the left side. And made the logic far more straightforward. This fixes issue #48.

Screenshots:
<img width="1325" alt="omnitone" src="https://cloud.githubusercontent.com/assets/4221553/23985368/f1dc5a22-09db-11e7-8314-749fb4080a99.png">
<img width="1322" alt="bae" src="https://cloud.githubusercontent.com/assets/4221553/23985370/f380aa40-09db-11e7-84c7-c8fe2075c893.png">
