### PR TITLE
observe an empty graph when selecting 'no' graph

### DIFF
--- a/src/panel/GraphSelector.js
+++ b/src/panel/GraphSelector.js
@@ -3,6 +3,9 @@
 
 import {Observer} from '../utils/Observer';
 
+const EMPTY_GRAPH = {
+  graph: {value: {width: 0, height: 0}, nodes: [], edges: []},
+};
 /**
  * Control which graph is observed.
  */
@@ -40,18 +43,15 @@ export class GraphSelector {
       () => this.graphId,
     );
     /** @type {Utils.Observer<Audion.GraphContext>} */
-    this.graphObserver = Observer.filter(
-      Observer.transform(
-        Observer.props(
-          {id: this.graphIdObserver, allGraphs: allGraphsObserver},
-          {
-            id: '',
-            allGraphs: /** @type {Object<string, Audion.GraphContext>} */ ({}),
-          },
-        ),
-        (value) => value.allGraphs[value.id],
+    this.graphObserver = Observer.transform(
+      Observer.props(
+        {id: this.graphIdObserver, allGraphs: allGraphsObserver},
+        {
+          id: '',
+          allGraphs: /** @type {Object<string, Audion.GraphContext>} */ ({}),
+        },
       ),
-      (value) => Boolean(value),
+      (value) => value.allGraphs[value.id] || EMPTY_GRAPH,
     );
   }
 


### PR DESCRIPTION
Fix #100 

Remove the filter in GraphSelector. With the filter when the the last audio context is destroyed, like when navigating to a page without any web audio use, no graph is observed by the layout worker, and so no graph change is observed by the rendering, leaving whatever last graph that was rendered on screen.