### PR TITLE
Attach debugger only when panel is opened.

### DIFF
--- a/src/devtools/DevtoolsGraphPanel.js
+++ b/src/devtools/DevtoolsGraphPanel.js
@@ -12,8 +12,9 @@ import {chrome} from '../chrome';
 export class DevtoolsGraphPanel {
   /**
    * Create a DevtoolsGraphPanel.
+   * @param {Audion.DevtoolsObserver} devtoolsObserver
    */
-  constructor() {
+  constructor(devtoolsObserver) {
     this.onShow = null;
 
     chrome.devtools.panels.create('Web Audio', '', 'panel.html', (panel) => {
@@ -23,13 +24,7 @@ export class DevtoolsGraphPanel {
         }
       });
     });
-  }
 
-  /**
-   * Connects the DevtoolsObserver to the Chrome Runtime.
-   * @param {Audion.DevtoolsObserver} devtoolsObserver
-   */
-  connect(devtoolsObserver) {
     chrome.runtime.onConnect.addListener((port) => {
       const unsubscribe = devtoolsObserver.observe((graph) => {
         port.postMessage(graph);

--- a/src/devtools/DevtoolsGraphPanel.js
+++ b/src/devtools/DevtoolsGraphPanel.js
@@ -12,11 +12,24 @@ import {chrome} from '../chrome';
 export class DevtoolsGraphPanel {
   /**
    * Create a DevtoolsGraphPanel.
+   */
+  constructor() {
+    this.onShow = null;
+
+    chrome.devtools.panels.create('Web Audio', '', 'panel.html', (panel) => {
+      panel.onShown.addListener(() => {
+        if (this.onShow) {
+          this.onShow();
+        }
+      });
+    });
+  }
+
+  /**
+   * Connects the DevtoolsObserver to the Chrome Runtime.
    * @param {Audion.DevtoolsObserver} devtoolsObserver
    */
-  constructor(devtoolsObserver) {
-    chrome.devtools.panels.create('Web Audio', '', 'panel.html', () => {});
-
+  connect(devtoolsObserver) {
     chrome.runtime.onConnect.addListener((port) => {
       const unsubscribe = devtoolsObserver.observe((graph) => {
         port.postMessage(graph);

--- a/src/devtools/WebAudioEventObserver.js
+++ b/src/devtools/WebAudioEventObserver.js
@@ -35,33 +35,29 @@ export class WebAudioEventObserver extends Observer {
           );
         });
       };
-      const onNavigated = () => {
-        chrome.debugger.sendCommand(
-          {tabId},
-          ChromeDebuggerWebAudioDomain.Methods.enable,
-        );
-      };
 
-      chrome.debugger.attach({tabId}, debuggerVersion, () => {
-        chrome.debugger.sendCommand(
-          {tabId},
-          ChromeDebuggerWebAudioDomain.Methods.enable,
-        );
-      });
       chrome.debugger.onDetach.addListener(onDetach);
       chrome.debugger.onEvent.addListener(onEvent);
-      chrome.devtools.network.onNavigated.addListener(onNavigated);
 
       return () => {
         chrome.debugger.onDetach.removeListener(onDetach);
         chrome.debugger.onEvent.removeListener(onEvent);
-        chrome.devtools.network.onNavigated.removeListener(onNavigated);
         chrome.debugger.sendCommand(
           {tabId},
           ChromeDebuggerWebAudioDomain.Methods.disable,
         );
         chrome.debugger.detach({tabId}, () => {});
       };
+    });
+  }
+
+  /** Attaches the chrome.debugger to start observing events. */
+  attach() {
+    chrome.debugger.attach({tabId}, debuggerVersion, () => {
+      chrome.debugger.sendCommand(
+        {tabId},
+        ChromeDebuggerWebAudioDomain.Methods.enable,
+      );
     });
   }
 }

--- a/src/devtools/WebAudioEventObserver.test.js
+++ b/src/devtools/WebAudioEventObserver.test.js
@@ -17,6 +17,7 @@ describe('WebAudioEventObserver', () => {
   it('attachs to chrome.debugger', () => {
     const o = new WebAudioEventObserver();
     o.observe(() => {});
+    o.attach();
     expect(chrome.debugger.attach).toBeCalled();
     if (jest.isMockFunction(chrome.debugger.attach)) {
       /** @type {function} */ (chrome.debugger.attach.mock.calls[0][2])();
@@ -24,12 +25,12 @@ describe('WebAudioEventObserver', () => {
     expect(chrome.debugger.sendCommand).toBeCalled();
     expect(chrome.debugger.onDetach.addListener).toBeCalled();
     expect(chrome.debugger.onEvent.addListener).toBeCalled();
-    expect(chrome.devtools.network.onNavigated.addListener).toBeCalled();
   });
 
   it('reattach on unexpected detach', () => {
     const o = new WebAudioEventObserver();
     o.observe(() => {});
+    o.attach();
     if (jest.isMockFunction(chrome.debugger.attach)) {
       /** @type {function} */ (chrome.debugger.attach.mock.calls[0][2])();
     }
@@ -45,22 +46,9 @@ describe('WebAudioEventObserver', () => {
     expect(chrome.debugger.sendCommand).toBeCalledTimes(2);
   });
 
-  it('enables WebAudio debugger after navigation events', () => {
-    const o = new WebAudioEventObserver();
-    o.observe(() => {});
-    if (jest.isMockFunction(chrome.debugger.attach)) {
-      /** @type {function} */ (chrome.debugger.attach.mock.calls[0][2])();
-    }
-    if (jest.isMockFunction(chrome.devtools.network.onNavigated.addListener)) {
-      /** @type {function} */ (
-        chrome.devtools.network.onNavigated.addListener.mock.calls[0][0]
-      )();
-    }
-    expect(chrome.debugger.sendCommand).toBeCalledTimes(2);
-  });
-
   it('detachs from chrome.debugger on unsubscribe', () => {
     const o = new WebAudioEventObserver();
+    o.attach();
     const unsubscribe = o.observe(() => {});
     if (jest.isMockFunction(chrome.debugger.attach)) {
       /** @type {function} */ (chrome.debugger.attach.mock.calls[0][2])();
@@ -73,13 +61,13 @@ describe('WebAudioEventObserver', () => {
     expect(chrome.debugger.sendCommand).toBeCalledTimes(2);
     expect(chrome.debugger.onDetach.removeListener).toBeCalled();
     expect(chrome.debugger.onEvent.removeListener).toBeCalled();
-    expect(chrome.devtools.network.onNavigated.removeListener).toBeCalled();
   });
 
   it('forwards to WebAudio debugger protocol events', () => {
     const nextMock = jest.fn();
     const o = new WebAudioEventObserver();
     o.observe(nextMock);
+    o.attach();
     if (jest.isMockFunction(chrome.debugger.attach)) {
       /** @type {function} */ (chrome.debugger.attach.mock.calls[0][2])();
     }

--- a/src/devtools/main.js
+++ b/src/devtools/main.js
@@ -5,44 +5,40 @@ import {serializeGraphContext} from './serializeGraphContext';
 import {WebAudioEventObserver} from './WebAudioEventObserver';
 import {WebAudioGraphIntegrator} from './WebAudioGraphIntegrator';
 
-const panel = new DevtoolsGraphPanel();
+const webAudioEvents = new WebAudioEventObserver();
+const integrateMessages = new WebAudioGraphIntegrator(webAudioEvents);
+const graphThrottle = Observer.throttle(integrateMessages, {});
+
+const serializeGraph = Observer.transform(graphThrottle, serializeGraphContext);
+
+const graphMessage = Observer.transform(serializeGraph, (message) => ({
+  graphContext: message,
+}));
+
+// Persistently observe web audio events and integrate events into context
+// objects. Collect those into an object of all current graphs.
+/** @type {{allGraphs: Object<string, Audion.GraphContext>}} */
+const allGraphs = {allGraphs: {}};
+graphMessage.observe((message) => {
+  if (message.graphContext.graph) {
+    allGraphs.allGraphs[message.graphContext.id] = message.graphContext;
+  } else {
+    delete allGraphs.allGraphs[message.graphContext.id];
+  }
+});
+
+// When the panel is opened it'll connect to the devtools page, immediately send
+// the current set of graphs.
+/** @type {Audion.DevtoolsObserver} */
+const allGraphsOnSubscribe = Observer.onSubscribe(
+  graphMessage,
+  () => allGraphs,
+);
+
+const panel = new DevtoolsGraphPanel(allGraphsOnSubscribe);
 panel.onShow = () => {
   // Only trigger this initialization code on the first time the panel is
   // opened.
   panel.onShow = null;
-
-  const webAudioEvents = new WebAudioEventObserver();
-  const integrateMessages = new WebAudioGraphIntegrator(webAudioEvents);
-  const graphThrottle = Observer.throttle(integrateMessages, {});
-
-  const serializeGraph = Observer.transform(
-    graphThrottle,
-    serializeGraphContext,
-  );
-
-  const graphMessage = Observer.transform(serializeGraph, (message) => ({
-    graphContext: message,
-  }));
-
-  // Persistently observe web audio events and integrate events into context
-  // objects. Collect those into an object of all current graphs.
-  /** @type {{allGraphs: Object<string, Audion.GraphContext>}} */
-  const allGraphs = {allGraphs: {}};
-  graphMessage.observe((message) => {
-    if (message.graphContext.graph) {
-      allGraphs.allGraphs[message.graphContext.id] = message.graphContext;
-    } else {
-      delete allGraphs.allGraphs[message.graphContext.id];
-    }
-  });
-
-  // When the panel is opened it'll connect to the devtools page, immediately
-  // send the current set of graphs.
-  /** @type {Audion.DevtoolsObserver} */
-  const allGraphsOnSubscribe = Observer.onSubscribe(
-    graphMessage,
-    () => allGraphs,
-  );
-
-  panel.connect(allGraphsOnSubscribe);
+  webAudioEvents.attach();
 };


### PR DESCRIPTION
Previously, audion would attach the debugger as soon as any devtools panel is opened - this would show the browser's warning bar even before the user opened the DevTools panel. This PR delays attaching the debugger until the user actually opens the audion panel for the first time.

Fixes #105 