### PR TITLE
Do not re-attach on user-triggered detach.

### DIFF
--- a/src/devtools/WebAudioEventObserver.js
+++ b/src/devtools/WebAudioEventObserver.js
@@ -27,13 +27,10 @@ export class WebAudioEventObserver extends Observer {
       const onEvent = (debuggeeId, method, params) => {
         onNext({method, params});
       };
-      const onDetach = () => {
-        chrome.debugger.attach({tabId}, debuggerVersion, () => {
-          chrome.debugger.sendCommand(
-            {tabId},
-            ChromeDebuggerWebAudioDomain.Methods.enable,
-          );
-        });
+      const onDetach = ({tabId}, detachReason) => {
+        // TODO: Show a warning if the DevTools are still open and allow the
+        // user to re-attach manually, e.g. by pressing a button.
+        // See: https://developer.chrome.com/docs/extensions/reference/debugger/#type-DetachReason
       };
       const onNavigated = () => {
         chrome.debugger.sendCommand(

--- a/src/devtools/WebAudioEventObserver.test.js
+++ b/src/devtools/WebAudioEventObserver.test.js
@@ -27,22 +27,22 @@ describe('WebAudioEventObserver', () => {
     expect(chrome.devtools.network.onNavigated.addListener).toBeCalled();
   });
 
-  it('reattach on unexpected detach', () => {
+  it('does not reattach when user triggers detach', () => {
     const o = new WebAudioEventObserver();
     o.observe(() => {});
     if (jest.isMockFunction(chrome.debugger.attach)) {
       /** @type {function} */ (chrome.debugger.attach.mock.calls[0][2])();
     }
-    if (jest.isMockFunction(chrome.debugger.onDetach.addListener)) {
+    expect(chrome.debugger.attach).toBeCalledTimes(1);
+    if (
+      jest.isMockFunction(chrome.debugger.onDetach.addListener) &&
+      chrome.debugger.onDetach.addListener.mock.calls.length > 0
+    ) {
       /** @type {function} */ (
         chrome.debugger.onDetach.addListener.mock.calls[0][0]
-      )();
+      )({tabId: 'tab'}, 'canceled_by_user');
     }
-    expect(chrome.debugger.attach).toBeCalledTimes(2);
-    if (jest.isMockFunction(chrome.debugger.attach)) {
-      /** @type {function} */ (chrome.debugger.attach.mock.calls[1][2])();
-    }
-    expect(chrome.debugger.sendCommand).toBeCalledTimes(2);
+    expect(chrome.debugger.attach).toBeCalledTimes(1);
   });
 
   it('enables WebAudio debugger after navigation events', () => {


### PR DESCRIPTION
When clicking "Cancel" in the debugging warning bar, `onDetach` is fired with reason `"canceled_by_user"` and immediately re-attaches, showing the warning bar again. This PR removes the re-attach logic. Instead, the Web Audio DevTools panel should show a warning that they were detached, with a button to re-attach.

![image](https://user-images.githubusercontent.com/864168/133637336-0bd47fca-2bde-4432-a89d-a8759e1a67a4.png)

See: #107 