### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: 'submit'
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.2
+        with:
+          node-version: '14'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build extension
+        run: npm run build:chrome-extension
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          artifact: ./build/audion.zip
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,9 +2112,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {


### PR DESCRIPTION
Hi Chrome team! :) 

We created a [Github action](https://github.com/marketplace/actions/browser-plugin-publisher) to make it easier to publish extensions to the various web stores programatically. 

Thought y'all might find it useful so I added a Github workflow that will run the build step and publish to the Chrome web store on dispatch.

The only thing you would need to create is a `SUBMIT_KEYS` GitHub repository secret.

This secret is a JSON, with the schema defined [here](https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json).

Here's a sample key:

```
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "zip": "./extension/chrome.zip",
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "./extension/firefox.xpi",
    "apiKey": "123",
    "apiSecret": "abcd",
    "extId": "foobar"
  }
}
```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me.

Otherwise, if this doesn't seem necessary, feel free to close the PR!

(p.s. it shows I commited the dependabot due to a rebase) 