### PR TITLE
fix: replace devtools sampleTime with auditTime

### DIFF
--- a/src/devtools/main.ts
+++ b/src/devtools/main.ts
@@ -5,9 +5,8 @@ import {
   take,
   shareReplay,
   share,
-  sampleTime,
-  takeLast,
   mergeMap,
+  auditTime,
 } from 'rxjs/operators';
 
 import {Audion} from './Types';
@@ -32,9 +31,9 @@ const serializedGraphContext$ = webAudioEvents$.pipe(
     getPartitionId: ({id}) => id,
     isPartitionComplete: ({context}) => context === null,
   }),
-  // For each partition, limit updates to the last value every given interval or
-  // the very last value when the partition completes.
-  (source) => merge(source.pipe(sampleTime(50)), source.pipe(takeLast(1))),
+  // For each partition, start a timer on the first value in that partition but
+  // emit the last value during that timer when the timer completes.
+  map(auditTime(16)),
   // Merge all the partitions together.
   mergeMap((source) => source),
   map(serializeGraphContext),


### PR DESCRIPTION
`sampleTime` emits last value every timer emission. The timer runs continuously. 

`auditTime` emits last value at the timer emission. `auditTime`'s timer starts on the first emission when the timer is not active. This makes `auditTime` the "inverse" of `throttleTime`. `throttleTime` emits the first value during its timer window (the same value that initiates the timer), and `auditTime` emits the last value from its timer window.

This means `sampleTime` emits a value after every interval whether the source emitted a value or not. Replacing `sampleTime` with `auditTime` we can increase the time the extension spends being idle.