### PR TITLE
Patch graph context

### DIFF
--- a/src/devtools/Types.ts
+++ b/src/devtools/Types.ts
@@ -22,6 +22,7 @@ export namespace Audion {
 
   export interface GraphContext {
     id: Protocol.WebAudio.GraphObjectId;
+    eventCount: number;
     context: Protocol.WebAudio.BaseAudioContext;
     realtimeData: ContextRealtimeData;
     nodes: {[key: string]: GraphNode};

--- a/src/devtools/WebAudioGraphIntegrator.test.js
+++ b/src/devtools/WebAudioGraphIntegrator.test.js
@@ -42,6 +42,7 @@ Array [
       "maxOutputChannelCount": 2,
       "sampleRate": 48000,
     },
+    "eventCount": 1,
     "graph": Graph {
       "_defaultEdgeLabelFn": [Function],
       "_defaultNodeLabelFn": [Function],
@@ -92,6 +93,7 @@ Array [
       "maxOutputChannelCount": 2,
       "sampleRate": 48000,
     },
+    "eventCount": 2,
     "graph": Graph {
       "_defaultEdgeLabelFn": [Function],
       "_defaultNodeLabelFn": [Function],
@@ -135,6 +137,7 @@ Array [
 Array [
   Object {
     "context": null,
+    "eventCount": 2,
     "graph": null,
     "id": "context0000",
     "nodes": null,
@@ -166,6 +169,7 @@ Array [
       "maxOutputChannelCount": 2,
       "sampleRate": 48000,
     },
+    "eventCount": 2,
     "graph": Graph {
       "_defaultEdgeLabelFn": [Function],
       "_defaultNodeLabelFn": [Function],
@@ -253,6 +257,7 @@ Array [
       "maxOutputChannelCount": 2,
       "sampleRate": 48000,
     },
+    "eventCount": 3,
     "graph": Graph {
       "_defaultEdgeLabelFn": [Function],
       "_defaultNodeLabelFn": [Function],
@@ -314,6 +319,7 @@ Array [
       "maxOutputChannelCount": 2,
       "sampleRate": 48000,
     },
+    "eventCount": 4,
     "graph": Graph {
       "_defaultEdgeLabelFn": [Function],
       "_defaultNodeLabelFn": [Function],
@@ -472,6 +478,7 @@ Array [
       "maxOutputChannelCount": 2,
       "sampleRate": 48000,
     },
+    "eventCount": 5,
     "graph": Graph {
       "_defaultEdgeLabelFn": [Function],
       "_defaultNodeLabelFn": [Function],
@@ -534,7 +541,13 @@ Array [
         "params": Array [],
       },
       "node0001": Object {
-        "edges": Array [],
+        "edges": Array [
+          Object {
+            "contextId": "context0000",
+            "destinationId": "node0000",
+            "sourceId": "node0001",
+          },
+        ],
         "node": Object {
           "channelCountMode": "max",
           "channelInterpretation": "discrete",

--- a/src/devtools/WebAudioGraphIntegrator.ts
+++ b/src/devtools/WebAudioGraphIntegrator.ts
@@ -56,6 +56,7 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
       return;
     }
     const context = space.graphContext;
+    context.eventCount += 1;
     if (context.nodes[audioNodeCreated.node.nodeId]) {
       console.warn(
         `Duplicate ${WebAudioDebuggerEvent.audioNodeCreated} event.`,
@@ -90,6 +91,7 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
       return;
     }
     const context = space.graphContext;
+    context.eventCount += 1;
     context.graph.removeNode(audioNodeDestroyed.nodeId);
     const node = context.nodes[audioNodeDestroyed.nodeId];
     if (node && node.params) {
@@ -111,6 +113,7 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
       return;
     }
     const context = space.graphContext;
+    context.eventCount += 1;
     const node = context.nodes[audioParamCreated.param.nodeId];
     if (!node) {
       return;
@@ -140,6 +143,7 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
       return;
     }
     const context = space.graphContext;
+    context.eventCount += 1;
     const node = context.nodes[audioParamWillBeDestroyed.nodeId];
     removeAll(
       node?.params,
@@ -158,6 +162,7 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
       return;
     }
     space.graphContext.context = contextChanged.context;
+    space.graphContext.eventCount += 1;
     return contexts[contextChanged.context.contextId].graphContext;
   },
 
@@ -187,6 +192,7 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
     contexts[contextCreated.context.contextId] = {
       graphContext: {
         id: contextId,
+        eventCount: 1,
         context: contextCreated.context,
         realtimeData: INITIAL_CONTEXT_REALTIME_DATA,
         nodes: {},
@@ -229,10 +235,12 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
     contexts,
     contextDestroyed,
   ) => {
+    const context = contexts[contextDestroyed.contextId];
     delete contexts[contextDestroyed.contextId];
 
     return {
       id: contextDestroyed.contextId,
+      eventCount: context?.graphContext?.eventCount + 1,
       context: null,
       realtimeData: null,
       nodes: null,
@@ -252,6 +260,7 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
     }
     const context = space.graphContext;
     context.nodes[nodeParamConnected.sourceId].edges.push(nodeParamConnected);
+    context.eventCount += 1;
     const {
       sourceId,
       sourceOutputIndex = 0,
@@ -282,6 +291,7 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
       return;
     }
     const context = space.graphContext;
+    context.eventCount += 1;
     const {edges} = context.nodes[nodesDisconnected.sourceId];
     const {sourceId, sourceOutputIndex = 0, destinationId} = nodesDisconnected;
     removeAll(
@@ -309,6 +319,7 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
     }
     const context = space.graphContext;
     context.nodes[nodesConnected.sourceId].edges.push(nodesConnected);
+    context.eventCount += 1;
     const {
       sourceId,
       sourceOutputIndex = 0,
@@ -339,6 +350,7 @@ const EVENT_HANDLERS: Partial<EventHandlers> = {
       return;
     }
     const context = space.graphContext;
+    context.eventCount += 1;
     const {edges} = context.nodes[nodesDisconnected.sourceId];
     const {
       sourceId,

--- a/src/devtools/patchGraphContext.ts
+++ b/src/devtools/patchGraphContext.ts
@@ -1,0 +1,62 @@
+import {
+  deserializeGraphContext,
+  SerializedGraphContext,
+} from './deserializeGraphContext';
+import {Audion} from './Types';
+
+export function patchGraphContext(
+  hydratedGraphContext: Audion.GraphContext,
+  serializedGraphContext: SerializedGraphContext,
+) {
+  if (
+    hydratedGraphContext.id !== serializedGraphContext.id ||
+    hydratedGraphContext.eventCount !== serializedGraphContext.eventCount
+  ) {
+    return deserializeGraphContext(serializedGraphContext);
+  }
+
+  const nodeIdSet = new Set(hydratedGraphContext.graph.nodes());
+  const edgeIdSet = new Set(hydratedGraphContext.graph.edges());
+
+  for (let i = 0; i < serializedGraphContext.graph.nodes.length; i++) {
+    const serializedNode = serializedGraphContext.graph.nodes[i];
+    if (!hydratedGraphContext.graph.hasNode(serializedNode.v)) {
+      nodeIdSet.delete(serializedNode.v);
+      hydratedGraphContext.graph.setNode(
+        serializedNode.v,
+        serializedNode.value,
+      );
+    } else {
+      Object.assign(
+        hydratedGraphContext.graph.node(serializedNode.v),
+        serializedNode.value,
+      );
+    }
+  }
+  for (let i = 0; i < serializedGraphContext.graph.edges.length; i++) {
+    const serializedEdge = serializedGraphContext.graph.edges[i];
+    if (!hydratedGraphContext.graph.hasEdge(serializedEdge)) {
+      edgeIdSet.delete(hydratedGraphContext.graph.edge(serializedEdge));
+      hydratedGraphContext.graph.setEdge(
+        serializedEdge.v,
+        serializedEdge.w,
+        serializedEdge.value,
+        serializedEdge.name,
+      );
+    } else {
+      Object.assign(
+        hydratedGraphContext.graph.edge(serializedEdge),
+        serializedEdge.value,
+      );
+    }
+  }
+
+  for (const nodeId of nodeIdSet) {
+    hydratedGraphContext.graph.removeNode(nodeId);
+  }
+  for (const edgeId of edgeIdSet) {
+    hydratedGraphContext.graph.removeEdge(edgeId);
+  }
+
+  return hydratedGraphContext;
+}

--- a/src/panel/GraphSelector.ts
+++ b/src/panel/GraphSelector.ts
@@ -1,17 +1,11 @@
-import {Observable, merge} from 'rxjs';
-import {map, shareReplay, scan} from 'rxjs/operators';
+import {Observable, combineLatest, BehaviorSubject} from 'rxjs';
+import {map, shareReplay, distinctUntilChanged} from 'rxjs/operators';
 
 import {Audion} from '../devtools/Types';
-
-import {Utils} from '../utils/Types';
-import {Observer} from '../utils/Observer';
-import {toRX} from '../utils/rxInterop';
 
 type GraphMap = {[key: string]: Audion.GraphContext};
 
 type GraphMapRX = Observable<GraphMap>;
-
-type GraphMapObserver = Utils.Observer<GraphMap>;
 
 const EMPTY_GRAPH = {
   graph: {value: {width: 0, height: 0}, nodes: [], edges: []},
@@ -21,112 +15,43 @@ const EMPTY_GRAPH = {
  * Control which graph is observed.
  */
 export class GraphSelector {
-  graphId: string;
-  _select: (graphId: string) => void;
-  optionsObserver: Utils.Observer<string[]>;
-  optionsObserver$: Observable<string[]>;
-  graphIdObserver: Utils.Observer<string>;
-  graphIdObserver$: Observable<string>;
-  propsObserver: Utils.Observer<{
-    id: string;
-    allGraphs: Audion.GraphContextsById;
-  }>;
-  graphObserver: Utils.Observer<Audion.GraphContext>;
-  graphObserver$: Observable<Audion.GraphContext>;
+  options$: Observable<string[]>;
+  graphId$: Observable<string>;
+  graph$: Observable<Audion.GraphContext>;
+
+  private _graphIdSubject: BehaviorSubject<string>;
+
+  get graphId(): string {
+    return this._graphIdSubject.value;
+  }
 
   /**
    * Create a GraphSelector.
    * @param options
-   * @param options.allGraphsObserver
-   * @param options.allGraphsObserver$
    */
-  constructor({
-    allGraphsObserver,
-    allGraphsObserver$,
-  }: {
-    allGraphsObserver: GraphMapObserver;
-    allGraphsObserver$: GraphMapRX;
-  }) {
-    this.graphId = '';
-    this._select = this.select.bind(this);
-    this.select = this._select;
-
-    this.optionsObserver = Observer.transform(allGraphsObserver, (allGraphs) =>
-      Object.entries(allGraphs)
-        .filter(([key, graphContext]) => graphContext)
-        .map(([key]) => key),
-    );
-    this.optionsObserver$ = map((allGraphs) =>
-      Object.entries(allGraphs)
-        .filter(([key, graphContext]) => graphContext)
-        .map(([key]) => key),
-    )(allGraphsObserver$);
-
-    this.graphIdObserver = Observer.onSubscribe(
-      new Observer((onNext, ...args) => {
-        this.select = (id) => {
-          if (id !== this.graphId) {
-            this.graphId = id;
-            onNext(id);
-          }
-        };
-        return () => {
-          this.select = this._select;
-        };
-      }),
-      () => this.graphId,
-    );
-    const latest$ = new Observable<string>((subscriber) => {
-      subscriber.next(this.graphId);
-      subscriber.complete();
-    });
-    const gio$ = new Observable<string>((subscriber) => {
-      this.select = (id) => {
-        if (id !== this.graphId) {
-          this.graphId = id;
-          subscriber.next(id);
-        }
-      };
-      return () => {
-        this.select = this._select;
-      };
-    });
-    // this.graphIdObserver$ = concat(latest$, gio$.pipe(share()));
-    this.graphIdObserver$ = toRX(this.graphIdObserver).pipe(shareReplay(1));
-
-    this.propsObserver = Observer.props(
-      {id: this.graphIdObserver, allGraphs: allGraphsObserver},
-      {
-        id: '',
-        allGraphs: {} as GraphMap,
-      },
-    );
-    this.graphObserver = Observer.transform(
-      Observer.props(
-        {id: this.graphIdObserver, allGraphs: allGraphsObserver},
-        {
-          id: '',
-          allGraphs: {} as GraphMap,
-        },
+  constructor({allGraphs$: allGraphs$}: {allGraphs$: GraphMapRX}) {
+    this.options$ = allGraphs$.pipe(
+      map((allGraphs) =>
+        Object.entries(allGraphs)
+          .filter(([key, graphContext]) => graphContext)
+          .map(([key]) => key),
       ),
-      (value) => value.allGraphs[value.id] || EMPTY_GRAPH,
-    ) as any;
-    this.graphObserver$ = merge(
-      this.graphIdObserver$.pipe(map((value) => ({id: value}))),
-      allGraphsObserver$.pipe(map((value) => ({allGraphs: value}))),
-    ).pipe(
-      scan((accum, value) => ({...accum, ...value}), {
-        id: '',
-        allGraphs: {} as GraphMap,
-      }),
+    );
+
+    const graphIdSubject = new BehaviorSubject('');
+    this._graphIdSubject = graphIdSubject;
+    this.graphId$ = graphIdSubject;
+
+    const props$ = combineLatest({
+      id: this.graphId$,
+      allGraphs: allGraphs$,
+    });
+
+    this.graph$ = props$.pipe(
       map(({id, allGraphs}) => allGraphs[id] || EMPTY_GRAPH),
+      distinctUntilChanged(),
       shareReplay(1),
     );
-    // this.graphObserver$ = zip(this.graphIdObserver$, allGraphsObserver$).pipe(
-    //   map(([id, allGraphs]) => ({id, allGraphs})),
-    //   startWith({id: '', allGraphs: {}}),
-    //   map(({id, allGraphs}) => allGraphs[id] || EMPTY_GRAPH),
-    // );
   }
 
   /**
@@ -134,10 +59,8 @@ export class GraphSelector {
    * @param graphId
    */
   select(graphId: string) {
-    this.graphId = graphId;
+    if (graphId !== this.graphId) {
+      this._graphIdSubject.next(graphId);
+    }
   }
 }
-
-/** @typedef {Object<string, Audion.GraphContext>} GraphMap */
-
-/** @typedef {Utils.Observer<GraphMap>} GraphMapObserver */

--- a/src/panel/worker.ts
+++ b/src/panel/worker.ts
@@ -5,6 +5,8 @@ import {
   distinctUntilChanged,
   filter,
   map,
+  mergeWith,
+  scan,
   startWith,
   withLatestFrom,
 } from 'rxjs/operators';
@@ -14,6 +16,7 @@ import {
   deserializeGraphContext,
   SerializedGraphContext,
 } from '../devtools/deserializeGraphContext';
+import {patchGraphContext} from '../devtools/patchGraphContext';
 
 interface LayoutOptionsMessage {
   layoutOptions: dagre.GraphLabel;
@@ -43,7 +46,7 @@ messages$
       (a, b) => a?.id === b?.id && a?.eventCount === b?.eventCount,
     ),
     auditTime(16),
-    map((graphContext) => deserializeGraphContext(graphContext)),
+    scan(patchGraphContext, {id: ''}),
     withLatestFrom(layoutOptions$),
     map(([context, layoutOptions]) => {
       if (context.context && context.graph) {


### PR DESCRIPTION
This builds on https://github.com/GoogleChrome/audion/pull/132 and will be a draft pr until that is merged.

When a serialized graph is received by the worker, if it is the same graph id as the last one that was deserialized, patch the old graph with the new information. Add new nodes and edges, and remove old nodes and edges. If a serialized graph with a different id is received deserialize the whole graph as it is for any graph received before this change.

This decreases the time spent by the worker determining the graph layout for incremental changes.