### PR TITLE
Detect stale contexts

### DIFF
--- a/src/chrome/DebuggerPageDomain.ts
+++ b/src/chrome/DebuggerPageDomain.ts
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Strings passed to `chrome.debugger.sendCommand` and received from
+ * `chrome.debugger.onEvent` callbacks.
+ */
+
+import {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping';
+
+/** @see https://chromedevtools.github.io/devtools-protocol/tot/Page/#methods */
+export enum PageDebuggerMethod {
+  disable = 'Page.disable',
+  enable = 'Page.enable',
+}
+
+/** @see https://chromedevtools.github.io/devtools-protocol/tot/Page/#events */
+export enum PageDebuggerEvent {
+  domContentEventFired = 'Page.domContentEventFired',
+  frameAttached = 'Page.frameAttached',
+  frameDetached = 'Page.frameDetached',
+  frameNavigated = 'Page.frameNavigated',
+  frameRequestedNavigation = 'Page.frameRequestedNavigation',
+  frameStartedLoading = 'Page.frameStartedLoading',
+  frameStoppedLoading = 'Page.frameStoppedLoading',
+  lifecycleEvent = 'Page.lifecycleEvent',
+  loadEventFired = 'Page.loadEventFired',
+}
+
+/** @see https://chromedevtools.github.io/devtools-protocol/tot/Page/#types */
+export type PageDebuggerEventParams<Name extends PageDebuggerEvent> =
+  ProtocolMapping.Events[Name];

--- a/src/devtools.html
+++ b/src/devtools.html
@@ -3,6 +3,6 @@
     <title>DevTools: Audion Extension</title>
   </head>
   <body>
-    <script src="devtools.js"></script>
+    <script src="audion-devtools.js"></script>
   </body>
 </html>

--- a/src/devtools/DebuggerEvents.ts
+++ b/src/devtools/DebuggerEvents.ts
@@ -1,0 +1,44 @@
+import {filter, map, Observable} from 'rxjs';
+import {chrome} from '../chrome';
+import {fromChromeEvent} from '../utils/rxChrome';
+import {DebuggerAttachEventController} from './DebuggerAttachEventController';
+import {Audion} from './Types';
+
+type DebuggerDomain = 'page' | 'webAudio';
+
+interface DebuggerEventsOptions<D extends DebuggerDomain> {
+  domain: D;
+}
+
+type DebuggerDomainEvent<D extends DebuggerDomain> = D extends 'page'
+  ? Audion.PageEvent
+  : D extends 'webAudio'
+  ? Audion.WebAudioEvent
+  : never;
+
+export class DebuggerEventsObservable<
+  D extends DebuggerDomain,
+> extends Observable<DebuggerDomainEvent<D>> {
+  constructor(
+    public attachController: DebuggerAttachEventController,
+    public options: DebuggerEventsOptions<D>,
+  ) {
+    super((subscriber) => {
+      attachController.attachInterest$.increment();
+      attachController[options.domain + 'EventInterest$'].increment();
+      const subscription = fromChromeEvent(chrome.debugger.onEvent)
+        .pipe(
+          map(([debuggeeId, method, params]) => ({method, params})),
+          filter(({method}) =>
+            method.toLowerCase().startsWith(options.domain.toLowerCase()),
+          ),
+        )
+        .subscribe(subscriber);
+      subscription.add(() => {
+        attachController.attachInterest$.decrement();
+        attachController[options.domain + 'EventInterest$'].decrement();
+      });
+      return subscription;
+    });
+  }
+}

--- a/src/devtools/Types.ts
+++ b/src/devtools/Types.ts
@@ -1,6 +1,10 @@
 /// <reference path="../chrome/DebuggerWebAudioDomain.ts" />
 
 import {Protocol} from 'devtools-protocol/types/protocol';
+import {
+  PageDebuggerEvent,
+  PageDebuggerEventParams,
+} from '../chrome/DebuggerPageDomain';
 
 import {
   WebAudioDebuggerEvent,
@@ -88,6 +92,11 @@ export namespace Audion {
     params: Protocol.WebAudio.AudioParam[];
     edges: Protocol.WebAudio.NodesConnectedEvent[];
   }
+
+  export type PageEvent<N extends PageDebuggerEvent = PageDebuggerEvent> = {
+    method: N;
+    params: PageDebuggerEventParams<N>[0];
+  };
 
   export type WebAudioEvent<
     N extends WebAudioDebuggerEvent = WebAudioDebuggerEvent,

--- a/src/devtools/main.ts
+++ b/src/devtools/main.ts
@@ -14,17 +14,23 @@ import {Audion} from './Types';
 import {DebuggerAttachEventController} from './DebuggerAttachEventController';
 import {DevtoolsGraphPanel} from './DevtoolsGraphPanel';
 import {serializeGraphContext} from './serializeGraphContext';
-import {WebAudioEventObservable} from './WebAudioEventObserver';
 import {integrateWebAudioGraph} from './WebAudioGraphIntegrator';
 import {WebAudioRealtimeData} from './WebAudioRealtimeData';
 import {partitionMap} from './partitionMap';
+import {DebuggerEventsObservable} from './DebuggerEvents';
 
 const attachController = new DebuggerAttachEventController();
 
-const webAudioEvents$ = new WebAudioEventObservable(attachController);
+const pageEvent$ = new DebuggerEventsObservable(attachController, {
+  domain: 'page',
+});
+const webAudioEvents$ = new DebuggerEventsObservable(attachController, {
+  domain: 'webAudio',
+});
 const webAudioRealtimeData = new WebAudioRealtimeData();
 
 const serializedGraphContext$ = merge(
+  pageEvent$,
   webAudioEvents$,
   attachController.debuggerEvent$,
 ).pipe(

--- a/src/panel.html
+++ b/src/panel.html
@@ -408,6 +408,6 @@
         <div><p>Loading ...</p></div>
       </div>
     </div>
-    <script src="panel.js"></script>
+    <script src="audion-panel.js"></script>
   </body>
 </html>

--- a/src/panel/graph/AudioNodeBackgroundRenderCacheGroup.ts
+++ b/src/panel/graph/AudioNodeBackgroundRenderCacheGroup.ts
@@ -22,7 +22,6 @@ export class AudioNodeBackgroundCache {
 
   getBackground(node: Audion.GraphNode) {
     if (!this.cache.has(node.node.nodeType)) {
-      console.log(node);
       const background = new AudioNodeBackground();
       background.init(AudioNodeMetrics.from(node, this.textCacheGroup));
       this.cache.set(node.node.nodeType, background);

--- a/src/panel/main.ts
+++ b/src/panel/main.ts
@@ -87,7 +87,7 @@ const graphContainer =
 const graphRender = new AudioGraphRender({elementContainer: graphContainer});
 graphRender.init();
 
-const layoutWorker = new Worker('panelWorker.js');
+const layoutWorker = new Worker('audion-panelWorker.js');
 
 graphSelector.graph$
   .pipe(

--- a/src/utils/rxChrome.ts
+++ b/src/utils/rxChrome.ts
@@ -1,0 +1,34 @@
+import {Observable} from 'rxjs';
+import {chrome} from '../chrome';
+
+/**
+ * Create a function that returns an observable that completes when the api
+ * calls back.
+ * @param method `chrome` api method whose last argument is a callback
+ * @param thisArg `this` inside of the method
+ * @returns observable that completes when the method is done
+ */
+export function bindChromeCallback<P extends any[], R extends any[]>(
+  method: (...args: [...params: P, callback: (...values: R) => void]) => void,
+  thisArg = null,
+) {
+  return (...args: P) =>
+    new Observable<R extends [] ? void : R extends [infer R1] ? R1 : R>(
+      (subscriber) => {
+        method.call(thisArg, ...args, (...returnValues: R) => {
+          if (chrome.runtime.lastError) {
+            subscriber.error(chrome.runtime.lastError);
+          } else {
+            if (returnValues.length === 0) {
+              subscriber.next();
+            } else if (returnValues.length === 1) {
+              subscriber.next(returnValues[0]);
+            } else if (returnValues.length > 1) {
+              subscriber.next(returnValues as any);
+            }
+            subscriber.complete();
+          }
+        });
+      },
+    );
+}

--- a/src/utils/rxChrome.ts
+++ b/src/utils/rxChrome.ts
@@ -1,5 +1,6 @@
-import {Observable} from 'rxjs';
+import {fromEventPattern, Observable} from 'rxjs';
 import {chrome} from '../chrome';
+import {ChromeDebuggerAPIEvent} from '../devtools/DebuggerAttachEventController';
 
 /**
  * Create a function that returns an observable that completes when the api
@@ -32,3 +33,16 @@ export function bindChromeCallback<P extends any[], R extends any[]>(
       },
     );
 }
+
+export const fromChromeEvent = <T extends (...args: any) => any>(
+  onEvent: Chrome.Event<T>,
+) =>
+  fromEventPattern<
+    Parameters<T> extends infer T1
+      ? T1 extends []
+        ? void
+        : T1 extends [infer T2]
+        ? T2
+        : T1
+      : never
+  >(onEvent.addListener.bind(onEvent), onEvent.removeListener.bind(onEvent));

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -3,9 +3,9 @@ const {resolve} = require('path');
 module.exports = (env, argv) => ({
   context: __dirname,
   entry: {
-    devtools: './devtools/main',
-    panel: './panel/main',
-    panelWorker: './panel/worker',
+    'audion-devtools': './devtools/main',
+    'audion-panel': './panel/main',
+    'audion-panelWorker': './panel/worker',
   },
   output: {
     path: resolve(__dirname, '../build/audion'),


### PR DESCRIPTION
Fix #142 

- Request realtime data for offline contexts and swallow subsequent realtime only errors
- Move context clean up in event integrator to one code block in integrator
- Detect stale contexts after page navigation and load events
- Add logging
  - Append `audion-` to built js files to make logs origin clear when using chrome store or production builds
  - Log each created context
  - Log each destroyed context and why (received will be destroyed event, or cannot be found requesting realtime data)
  - Log when forced detection for stale contexts and why (debugger detached, frame navigated, load event)
